### PR TITLE
OPENAM-5379 CR-6791 remove ant task that fails due to missing folder

### DIFF
--- a/openam-server-only/openam-server-prepare-war.xml
+++ b/openam-server-only/openam-server-prepare-war.xml
@@ -187,13 +187,6 @@
             </fileset>
         </copy>
 
-        <!-- Align the Console Definitions for WAR Inclusion. -->
-        <copy todir="${project.build.directory}/classes" overwrite="false">
-            <fileset dir="${server.resources}/console">
-                <include name="*.properties"/>
-            </fileset>
-        </copy>
-
         <!-- Align the Service Definitions for WAR Inclusion. -->
         <copy todir="${project.build.directory}/classes" overwrite="false">
             <fileset dir="${server.resources}/services">


### PR DESCRIPTION
Build fails due to move from svn -> git. Git doesn't store empty directories, and because of this an ANT task failed due to a missing directory. This was fixed in [OPENAM-5379](https://bugster.forgerock.org/jira/browse/OPENAM-5379).

The fix is to remove the old ANT task that is not required.