### PR TITLE
Builds with CDDL license as the binary license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,8 +187,8 @@
         <siteDistributionURL>scp://forgerock.org/var/www/vhosts/openam.forgerock.org/httpdocs</siteDistributionURL>
 
         <!-- ForgeRock Binary License to package into the artifacts -->
-        <forgerock.license.groupId>com.forgerock</forgerock.license.groupId>
-        <forgerock.license.artifactId>binary-license</forgerock.license.artifactId>
+        <forgerock.license.groupId>org.forgerock</forgerock.license.groupId>
+        <forgerock.license.artifactId>cddl-license</forgerock.license.artifactId>
         <forgerock.license.version>1.0.0</forgerock.license.version>
     </properties>
 


### PR DESCRIPTION
fixes #4 

Binary license now pulls the cddl license text.