### PR TITLE
Switch from log4j to reload4j

### DIFF
--- a/openam-core/pom.xml
+++ b/openam-core/pom.xml
@@ -330,8 +330,8 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <cc-ui.version>2008-08-08</cc-ui.version>
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <jstl.version>1.1.2</jstl.version>
-        <reload4j.version>1.2.18.3</reload4j.version>
+        <reload4j.version>1.2.19</reload4j.version>
         <mail.version>1.4.5</mail.version>
         <jersey-oauth.version>1.1.5.2</jersey-oauth.version>
         <relaxngDatatype.version>20020414</relaxngDatatype.version>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <cc-ui.version>2008-08-08</cc-ui.version>
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <jstl.version>1.1.2</jstl.version>
-        <log4j.version>1.2.16</log4j.version>
+        <reload4j.version>1.2.18.3</reload4j.version>
         <mail.version>1.4.5</mail.version>
         <jersey-oauth.version>1.1.5.2</jersey-oauth.version>
         <relaxngDatatype.version>20020414</relaxngDatatype.version>
@@ -1146,9 +1146,9 @@
             </dependency>
 
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>${log4j.version}</version>
+                <groupId>ch.qos.reload4j</groupId>
+                <artifactId>reload4j</artifactId>
+                <version>${reload4j.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The apache project log4j 1 is no longer being updated, the origional
author has created reload4j to make some fixes

More details can be found here:

https://reload4j.qos.ch/